### PR TITLE
Reworked deployment for secure defaults

### DIFF
--- a/Curriculum/Module 02 - Reconnaissance/assignments/Assignment_2/Dockerfile
+++ b/Curriculum/Module 02 - Reconnaissance/assignments/Assignment_2/Dockerfile
@@ -1,3 +1,0 @@
-FROM vulnerables/cve-2014-6271:latest
-
-RUN echo "Flag{NMAP_1S_Y0UR_FR13ND}" > /flag

--- a/Curriculum/Module 02 - Reconnaissance/assignments/Assignment_2/docker-compose.yml
+++ b/Curriculum/Module 02 - Reconnaissance/assignments/Assignment_2/docker-compose.yml
@@ -2,14 +2,15 @@ version: '3.8'
 
 services:
   webserver:
-    image: nginx:latest
+    image: docker.io/library/nginx:latest
     ports:
       - "8080:80"
     networks:
       - recon-network
 
   ssh:
-    image: rastasheep/ubuntu-sshd:latest
+    build:
+      dockerfile: ssh.Dockerfile
     ports:
       - "2222:22"
     networks:
@@ -17,22 +18,27 @@ services:
 
   ftp:
     image: stilliard/pure-ftpd:hardened
+    environment:
+      FTP_USER_NAME: recon_ftp_user
+      FTP_USER_PASS: 9QkqOinPZfiuGEFo
     ports:
-      - "21:21"
+      - "2100:21"
     networks:
       - recon-network
 
   database:
-    image: mysql:latest
+    image: docker.io/library/mysql:latest
     environment:
-      MYSQL_ROOT_PASSWORD: rootpassword
+      MYSQL_ROOT_PASSWORD: kKkszlICX5GRd2JaCwyl
+      MYSQL_USER: recon_db_user
     ports:
       - "3306:3306"
     networks:
       - recon-network
 
   vulnerable-webserver:
-    build: .
+    build:
+      dockerfile: vuln.Dockerfile
     ports:
       - "17334:80"
     networks:

--- a/Curriculum/Module 02 - Reconnaissance/assignments/Assignment_2/ssh.Dockerfile
+++ b/Curriculum/Module 02 - Reconnaissance/assignments/Assignment_2/ssh.Dockerfile
@@ -1,0 +1,21 @@
+FROm docker.io/library/debian:bookworm-slim
+
+EXPOSE 22
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y openssh-server && \
+    # fix from https://askubuntu.com/questions/1110828/ssh-failed-to-start-missing-privilege-separation-directory-var-run-sshd
+    mkdir /var/run/sshd && \
+    # Disable Password-Authentication
+    sed -i "s/#PasswordAuthentication yes/PasswordAuthentication no/g" /etc/ssh/sshd_config && \
+    # Disable Root-Login
+    sed -i "s/#PermitRootLogin prohibit-password/PermitRootLogin no/g" /etc/ssh/sshd_config && \
+    # Disable Public-Key Authentication
+    sed -i "s/#PubkeyAuthentication yes/PubkeyAuthentication no/g" /etc/ssh/sshd_config && \
+    # Disable PAM
+    sed -i "s/UsePAM yes/UsePAM no/g" /etc/ssh/sshd_config &&\
+    # Do not permit empty passwords
+    sed -i "s/#PermitEmptyPasswords no/PermitEmptyPasswords no/g" /etc/ssh/sshd_config
+
+CMD ["/usr/sbin/sshd", "-D"]

--- a/Curriculum/Module 02 - Reconnaissance/assignments/Assignment_2/vuln.Dockerfile
+++ b/Curriculum/Module 02 - Reconnaissance/assignments/Assignment_2/vuln.Dockerfile
@@ -1,0 +1,3 @@
+FROM docker.io/vulnerables/cve-2014-6271:latest
+
+RUN echo "Flag{NMAP_1S_Y0UR_FR13ND}" > /flag


### PR DESCRIPTION
This PR reworks the ssh-container, explicitly sets passwords for the database- and the ftp-container and also uses fully qualified image-names (needed for podman-user)